### PR TITLE
Add Whence option to control where to start tailing the file

### DIFF
--- a/option.go
+++ b/option.go
@@ -27,3 +27,8 @@ func PollDelay(d time.Duration) Option {
 func PollTimeout(d time.Duration) Option {
 	return optionFunc(func(t *Tail) { t.pollTimeout = d })
 }
+
+// Whence lets you change where you want to start with tailing the file.
+func Whence(w int) Option {
+	return optionFunc(func(t *Tail) { t.whence = w })
+}

--- a/tail.go
+++ b/tail.go
@@ -27,6 +27,7 @@ type Tail struct {
 	f           *trackedFile
 	next        *trackedFile
 	lasterr     error
+	whence      int
 }
 
 // Follow starts tracking the path using polling.
@@ -42,6 +43,7 @@ func Follow(ctx context.Context, log Logger, path string, options ...Option) *Ta
 		pollDelay:   DefaultPollDelay,
 		pollTimeout: DefaultPollTimeout,
 		f:           newTrackedFile(ctx, path),
+		whence:      io.SeekEnd,
 	}
 	for _, option := range options {
 		option.apply(t)
@@ -49,7 +51,7 @@ func Follow(ctx context.Context, log Logger, path string, options ...Option) *Ta
 
 	err := t.f.Open()
 	if err == nil && t.f.Usual() {
-		_, err = t.f.Seek(0, io.SeekEnd)
+		_, err = t.f.Seek(0, t.whence)
 		if err != nil {
 			t.f.Close()
 		}


### PR DESCRIPTION
I'd like to be able to use this library to "follow" files but not necessarily starting from the tail.

This PR allows to pass a `tail.Whence(io.SeekStart)` option that control this behaviour.