### PR TITLE
fix: use O_RDONLY for regular files, reserve O_RDWR for FIFOs

### DIFF
--- a/open_unix.go
+++ b/open_unix.go
@@ -10,12 +10,24 @@ import (
 
 // openFile opens a file for reading in a platform-specific way.
 func openFile(path string) (*os.File, error) {
-	// Open the FIFO in read-write non-blocking mode:
-	// - O_RDWR ensures we never get EOF when reading because at least one writer is present.
-	// - O_NONBLOCK is required to have Close() interrupt the Read() call.
-	// - Also one of them is required to avoid blocking on Open() FIFO without writers.
-	// This shouldn't affect regular files (as long as we're not trying to write, of course).
-	fd, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK, 0)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var flags int
+	if fi.Mode()&os.ModeNamedPipe != 0 {
+		// Open FIFO in read-write non-blocking mode:
+		// - O_RDWR ensures we never get EOF when reading because at least one writer is present.
+		// - O_NONBLOCK is required to have Close() interrupt the Read() call.
+		// - Also one of them is required to avoid blocking on Open() FIFO without writers.
+		flags = unix.O_RDWR | unix.O_NONBLOCK
+	} else {
+		// Regular files only need read access.
+		flags = unix.O_RDONLY | unix.O_NONBLOCK
+	}
+
+	fd, err := unix.Open(path, flags, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/tail_test.go
+++ b/tail_test.go
@@ -320,6 +320,27 @@ func TestRotateSymlink(tt *testing.T) {
 	tail.Want(pollDelay*3/2, "new2\nold1.1\nold1.2\nnew1.1\nnew1.2\nnew2\n", nil)
 }
 
+func TestReadOnlyFile(tt *testing.T) {
+	if runtime.GOOS == "windows" {
+		tt.Skip("Permission tests work differently on Windows")
+	} else if os.Getuid() == 0 {
+		tt.Skip("Permission tests does not work as root")
+	}
+
+	t := check.T(tt)
+	t.Parallel()
+	tail := newTestTail(t)
+
+	// Make file read-only (no write permission for anyone).
+	t.Nil(os.Chmod(tail.path, 0o444))
+	tail.Run()
+
+	// Write via a separate fd opened before chmod.
+	tail.Write("new1\n")
+	tail.Want(pollDelay*3/2, "new1\n", nil)
+	tail.Want(pollTimeout+pollDelay/2, "", nil)
+}
+
 func TestErrors(tt *testing.T) {
 	if runtime.GOOS == "windows" {
 		tt.Skip("Permission tests work differently on Windows")


### PR DESCRIPTION
## Summary

`openFile()` unconditionally opens all files with `O_RDWR`, which is only needed for FIFOs (to prevent spurious EOF and avoid blocking on open without writers). This causes "permission denied" errors when tailing regular files that are readable but not writable by the current user — e.g. log files owned by `syslog` with mode `0644`.

This PR stats the path first to determine the file type:
- **FIFOs**: `O_RDWR|O_NONBLOCK` (preserves existing behavior)
- **Regular files**: `O_RDONLY|O_NONBLOCK` (no write access needed)

## Test plan

- [x] Added `TestReadOnlyFile`: creates a file, chmods to `0444`, verifies tailing still works
- [x] All existing tests pass, including `TestFIFOGrow` (FIFO behavior unchanged)
- [x] `TestErrors` (chmod 0 → no access at all) still correctly returns `EACCES`